### PR TITLE
Fixed Japanese typo for 'Controller Providers'.

### DIFF
--- a/source/providers.rst
+++ b/source/providers.rst
@@ -132,7 +132,7 @@
 
 .. _controller-providers:
 
-コントロラープロバイダー(Controllers providers)
+コントローラープロバイダー(Controllers providers)
 ---------------------------------------------------
 
 プロバイダーの読み込み


### PR DESCRIPTION
before: コントロラープロバイダ
after: コントローラープロバイダー
に変更しました
